### PR TITLE
[Test] 명함 생성 테스트코드 작성

### DIFF
--- a/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
+++ b/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
@@ -1,0 +1,21 @@
+//
+//  BusinessCardForm.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/27/26.
+//
+
+struct BusinessCardForm {
+    
+    var nickname: Nickname?
+    
+    enum BuildError: Error {
+        case missingNickname
+    }
+    
+    func build() throws {
+        guard let nickname else {
+            throw BuildError.missingNickname
+        }
+    }
+}

--- a/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
+++ b/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
@@ -13,19 +13,21 @@ struct BusinessCardForm {
     var domain: UserDomain?
     var cardColor: CardColor?
     
-    enum BuildError: Error {
-        case missingNickname
-        case missingName
-        case missingPhoneNumber
-        case missingDomain
-        case missingCardColor
-    }
-    
-    func build() throws {
-        guard let nickname else { throw BuildError.missingNickname }
-        guard let name else { throw BuildError.missingName }
-        guard let phoneNumber else { throw BuildError.missingPhoneNumber }
-        guard let domain else { throw BuildError.missingDomain }
-        guard let cardColor else { throw BuildError.missingCardColor }
+    func build() -> BusinessCard? {
+        guard let nickname,
+              let name,
+              let phoneNumber,
+              let domain,
+              let cardColor
+        else { return nil }
+        
+        return .init(
+            nickname: nickname,
+            name: name,
+            phoneNumber: phoneNumber,
+            field: domain,
+            cardColor: cardColor,
+            origin: CardOrigin.mine
+        )
     }
 }

--- a/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
+++ b/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
@@ -9,14 +9,17 @@ struct BusinessCardForm {
     
     var nickname: Nickname?
     var name: Name?
+    var phoneNumber: PhoneNumber?
     
     enum BuildError: Error {
         case missingNickname
         case missingName
+        case missingPhoneNumber
     }
     
     func build() throws {
         guard let nickname else { throw BuildError.missingNickname }
         guard let name else { throw BuildError.missingName }
+        guard let phoneNumber else { throw BuildError.missingPhoneNumber }
     }
 }

--- a/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
+++ b/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
@@ -8,14 +8,15 @@
 struct BusinessCardForm {
     
     var nickname: Nickname?
+    var name: Name?
     
     enum BuildError: Error {
         case missingNickname
+        case missingName
     }
     
     func build() throws {
-        guard let nickname else {
-            throw BuildError.missingNickname
-        }
+        guard let nickname else { throw BuildError.missingNickname }
+        guard let name else { throw BuildError.missingName }
     }
 }

--- a/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
+++ b/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
@@ -10,16 +10,19 @@ struct BusinessCardForm {
     var nickname: Nickname?
     var name: Name?
     var phoneNumber: PhoneNumber?
+    var domain: UserDomain?
     
     enum BuildError: Error {
         case missingNickname
         case missingName
         case missingPhoneNumber
+        case missingDomain
     }
     
     func build() throws {
         guard let nickname else { throw BuildError.missingNickname }
         guard let name else { throw BuildError.missingName }
         guard let phoneNumber else { throw BuildError.missingPhoneNumber }
+        guard let domain else { throw BuildError.missingDomain }
     }
 }

--- a/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
+++ b/Challenge2-BusinessCard/Domain/BusinessCardForm.swift
@@ -11,12 +11,14 @@ struct BusinessCardForm {
     var name: Name?
     var phoneNumber: PhoneNumber?
     var domain: UserDomain?
+    var cardColor: CardColor?
     
     enum BuildError: Error {
         case missingNickname
         case missingName
         case missingPhoneNumber
         case missingDomain
+        case missingCardColor
     }
     
     func build() throws {
@@ -24,5 +26,6 @@ struct BusinessCardForm {
         guard let name else { throw BuildError.missingName }
         guard let phoneNumber else { throw BuildError.missingPhoneNumber }
         guard let domain else { throw BuildError.missingDomain }
+        guard let cardColor else { throw BuildError.missingCardColor }
     }
 }

--- a/Challenge2-BusinessCard/Domain/CardColor.swift
+++ b/Challenge2-BusinessCard/Domain/CardColor.swift
@@ -1,0 +1,38 @@
+//
+//  CardColor.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/27/26.
+//
+
+import SwiftUI
+
+struct CardColor {
+    
+    var color: Color
+    
+    private enum ColorRule: CaseIterable {
+        case black
+        case blue
+        case red
+        case cyan
+        
+        var color: Color {
+            switch self {
+            case .black: .black
+            case .blue: .blue
+            case .red: .red
+            case .cyan: .cyan
+            }
+        }
+    }
+    
+    init?(color: Color) {
+        let isValidColor = ColorRule.allCases.first { $0.color == color }
+        guard let isValidColor else {
+            return nil
+        }
+        
+        self.color = color
+    }
+}

--- a/Challenge2-BusinessCard/Domain/CardColor.swift
+++ b/Challenge2-BusinessCard/Domain/CardColor.swift
@@ -29,7 +29,7 @@ struct CardColor {
     
     init?(color: Color) {
         let isValidColor = ColorRule.allCases.first { $0.color == color }
-        guard let isValidColor else {
+        guard let _ = isValidColor else {
             return nil
         }
         

--- a/Challenge2-BusinessCard/Domain/Name.swift
+++ b/Challenge2-BusinessCard/Domain/Name.swift
@@ -10,6 +10,9 @@ import Foundation
 struct Name {
     
     private var string: String
+    var toString: String {
+        string
+    }
     
     private enum NameRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[가-힣]{1,10}$")

--- a/Challenge2-BusinessCard/Domain/Name.swift
+++ b/Challenge2-BusinessCard/Domain/Name.swift
@@ -15,7 +15,7 @@ struct Name {
     }
     
     private enum NameRule {
-        static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[가-힣]{1,10}$")
+        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, "^[가-힣]{1,10}$")
     }
     
     init?(string: String) {

--- a/Challenge2-BusinessCard/Domain/Name.swift
+++ b/Challenge2-BusinessCard/Domain/Name.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Name {
     
-    let string: String
+    var string: String
     
     private enum NameRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[가-힣]{1,10}$")

--- a/Challenge2-BusinessCard/Domain/Name.swift
+++ b/Challenge2-BusinessCard/Domain/Name.swift
@@ -9,13 +9,14 @@ import Foundation
 
 struct Name {
     
+    private static let nameRegex = "^[가-힣]{1,10}$"
     private var string: String
     var toString: String {
         string
     }
     
     private enum NameRule {
-        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, "^[가-힣]{1,10}$")
+        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, nameRegex)
     }
     
     init?(string: String) {

--- a/Challenge2-BusinessCard/Domain/Name.swift
+++ b/Challenge2-BusinessCard/Domain/Name.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Name {
     
-    var string: String
+    private var string: String
     
     private enum NameRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[가-힣]{1,10}$")

--- a/Challenge2-BusinessCard/Domain/Nickname.swift
+++ b/Challenge2-BusinessCard/Domain/Nickname.swift
@@ -10,6 +10,9 @@ import Foundation
 struct Nickname {
     
     private var string: String
+    var toString: String {
+        string
+    }
     
     private enum NicknameRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[A-Z][a-z]{1,9}$")

--- a/Challenge2-BusinessCard/Domain/Nickname.swift
+++ b/Challenge2-BusinessCard/Domain/Nickname.swift
@@ -15,7 +15,7 @@ struct Nickname {
     }
     
     private enum NicknameRule {
-        static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[A-Z][a-z]{1,9}$")
+        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, "^[A-Z][a-z]{1,9}$")
     }
     
     init?(string: String) {

--- a/Challenge2-BusinessCard/Domain/Nickname.swift
+++ b/Challenge2-BusinessCard/Domain/Nickname.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Nickname {
     
-    let string: String
+    var string: String
     
     private enum NicknameRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[A-Z][a-z]{1,9}$")

--- a/Challenge2-BusinessCard/Domain/Nickname.swift
+++ b/Challenge2-BusinessCard/Domain/Nickname.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Nickname {
     
-    var string: String
+    private var string: String
     
     private enum NicknameRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^[A-Z][a-z]{1,9}$")

--- a/Challenge2-BusinessCard/Domain/Nickname.swift
+++ b/Challenge2-BusinessCard/Domain/Nickname.swift
@@ -9,13 +9,14 @@ import Foundation
 
 struct Nickname {
     
+    private static let nicknameRegex = "^[A-Z][a-z]{1,9}$"
     private var string: String
     var toString: String {
         string
     }
     
     private enum NicknameRule {
-        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, "^[A-Z][a-z]{1,9}$")
+        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, nicknameRegex)
     }
     
     init?(string: String) {

--- a/Challenge2-BusinessCard/Domain/PhoneNumber.swift
+++ b/Challenge2-BusinessCard/Domain/PhoneNumber.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct PhoneNumber {
     
+    private static let phoneNumberRegex = "^010[0-9]{8}$"
     private let prefixOffset: Int = 3
     private let suffixOffset: Int = 7
     private let seperator: Character = " "
@@ -29,7 +30,7 @@ struct PhoneNumber {
     }
     
     private enum PhoneNumberRule {
-        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, "^010[0-9]{8}$")
+        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, phoneNumberRegex)
     }
     
     init?(string: String) {

--- a/Challenge2-BusinessCard/Domain/PhoneNumber.swift
+++ b/Challenge2-BusinessCard/Domain/PhoneNumber.swift
@@ -29,7 +29,7 @@ struct PhoneNumber {
     }
     
     private enum PhoneNumberRule {
-        static let predicate = NSPredicate(format: "SELF MATCHES %@", "^010[0-9]{8}$")
+        static let predicate = NSPredicate(format: Validation.regexPredicateFormat, "^010[0-9]{8}$")
     }
     
     init?(string: String) {

--- a/Challenge2-BusinessCard/Domain/PhoneNumber.swift
+++ b/Challenge2-BusinessCard/Domain/PhoneNumber.swift
@@ -9,7 +9,24 @@ import Foundation
 
 struct PhoneNumber {
     
+    private let prefixOffset: Int = 3
+    private let suffixOffset: Int = 7
+    private let seperator: Character = " "
+    
     let string: String
+    
+    var formatted: String {
+        var numberString = string
+        [suffixOffset, prefixOffset].forEach {
+            insertSeparator(for: &numberString, at: $0)
+        }
+        
+        return numberString
+    }
+    
+    private func insertSeparator(for string: inout String, at offset: Int) {
+        string.insert(seperator, at: string.index(string.startIndex, offsetBy: offset))
+    }
     
     private enum PhoneNumberRule {
         static let predicate = NSPredicate(format: "SELF MATCHES %@", "^010[0-9]{8}$")

--- a/Challenge2-BusinessCard/Domain/PhoneNumber.swift
+++ b/Challenge2-BusinessCard/Domain/PhoneNumber.swift
@@ -13,7 +13,7 @@ struct PhoneNumber {
     private let suffixOffset: Int = 7
     private let seperator: Character = " "
     
-    let string: String
+    var string: String
     
     var formatted: String {
         var numberString = string

--- a/Challenge2-BusinessCard/Domain/PhoneNumber.swift
+++ b/Challenge2-BusinessCard/Domain/PhoneNumber.swift
@@ -1,0 +1,25 @@
+//
+//  PhoneNumber.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/26/26.
+//
+
+import Foundation
+
+struct PhoneNumber {
+    
+    let string: String
+    
+    private enum PhoneNumberRule {
+        static let predicate = NSPredicate(format: "SELF MATCHES %@", "^010[0-9]{8}$")
+    }
+    
+    init?(string: String) {
+        guard PhoneNumberRule.predicate.evaluate(with: string) else {
+            return nil
+        }
+        
+        self.string = string
+    }
+}

--- a/Challenge2-BusinessCard/Domain/PhoneNumber.swift
+++ b/Challenge2-BusinessCard/Domain/PhoneNumber.swift
@@ -13,7 +13,7 @@ struct PhoneNumber {
     private let suffixOffset: Int = 7
     private let seperator: Character = " "
     
-    var string: String
+    private var string: String
     
     var formatted: String {
         var numberString = string

--- a/Challenge2-BusinessCard/Domain/UserDomain.swift
+++ b/Challenge2-BusinessCard/Domain/UserDomain.swift
@@ -1,0 +1,19 @@
+//
+//  UserDomain.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/27/26.
+//
+
+struct UserDomain {
+    
+    private var field: Field
+    
+    var name: String {
+        field.name
+    }
+    
+    init(field: Field) {
+        self.field = field
+    }
+}

--- a/Challenge2-BusinessCard/Domain/Validation.swift
+++ b/Challenge2-BusinessCard/Domain/Validation.swift
@@ -1,0 +1,10 @@
+//
+//  Validation.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/29/26.
+//
+
+enum Validation {
+    static let regexPredicateFormat = "SELF MATCHES %@"
+}

--- a/Challenge2-BusinessCard/Model/BusinessCard.swift
+++ b/Challenge2-BusinessCard/Model/BusinessCard.swift
@@ -43,6 +43,24 @@ class BusinessCard {
         )
     }
     
+    convenience init(
+        nickname: Nickname,
+        name: Name,
+        phoneNumber: PhoneNumber,
+        field: UserDomain,
+        cardColor: CardColor,
+        origin: CardOrigin
+    ) {
+        self.init(
+            nickname: nickname.toString,
+            name: name.toString,
+            phoneNumber: phoneNumber.formatted,
+            field: field.name,
+            color: .init(color: cardColor.color),
+            origin: origin.rawValue
+        )
+    }
+    
     func toDTO() -> BusinessCardDTO {
         .init(
             nickname: nickname,

--- a/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
@@ -39,4 +39,16 @@ struct BusinessCardFormTests {
             try form.build()
         }
     }
+    
+    @Test
+    func 도메인이_없으면_명함은_생성되지_않는다() {
+        var form = BusinessCardForm()
+        form.nickname = Nickname(string: "Dustin")
+        form.name = Name(string: "가나다")
+        form.phoneNumber = PhoneNumber(string: "01012345678")
+        
+        #expect(throws: BusinessCardForm.BuildError.missingDomain) {
+            try form.build()
+        }
+    }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
@@ -5,6 +5,7 @@
 //  Created by 더스틴 on 4/26/26.
 //
 
+import SwiftUI
 import Testing
 @testable import Challenge2_BusinessCard
 
@@ -14,9 +15,9 @@ struct BusinessCardFormTests {
     func 닉네임이_없으면_명함은_생성되지_않는다() {
         let form = BusinessCardForm()
         
-        #expect(throws: BusinessCardForm.BuildError.missingNickname) {
-            try form.build()
-        }
+        let result = form.build()
+        
+        #expect(result == nil)
     }
     
     @Test
@@ -24,9 +25,9 @@ struct BusinessCardFormTests {
         var form = BusinessCardForm()
         form.nickname = Nickname(string: "Dustin")
         
-        #expect(throws: BusinessCardForm.BuildError.missingName) {
-            try form.build()
-        }
+        let result = form.build()
+        
+        #expect(result == nil)
     }
     
     @Test
@@ -35,9 +36,9 @@ struct BusinessCardFormTests {
         form.nickname = Nickname(string: "Dustin")
         form.name = Name(string: "가나다")
         
-        #expect(throws: BusinessCardForm.BuildError.missingPhoneNumber) {
-            try form.build()
-        }
+        let result = form.build()
+        
+        #expect(result == nil)
     }
     
     @Test
@@ -47,9 +48,9 @@ struct BusinessCardFormTests {
         form.name = Name(string: "가나다")
         form.phoneNumber = PhoneNumber(string: "01012345678")
         
-        #expect(throws: BusinessCardForm.BuildError.missingDomain) {
-            try form.build()
-        }
+        let result = form.build()
+        
+        #expect(result == nil)
     }
     
     @Test
@@ -60,8 +61,22 @@ struct BusinessCardFormTests {
         form.phoneNumber = PhoneNumber(string: "01012345678")
         form.domain = UserDomain(field: .tech)
         
-        #expect(throws: BusinessCardForm.BuildError.missingCardColor) {
-            try form.build()
-        }
+        let result = form.build()
+        
+        #expect(result == nil)
+    }
+    
+    @Test
+    func 닉네임_이름_전화번호_도메인_명함색상이_모두_입력되어야_명함을_생성할_수_있다() {
+        var form = BusinessCardForm()
+        form.nickname = Nickname(string: "Dustin")
+        form.name = Name(string: "가나다")
+        form.phoneNumber = PhoneNumber(string: "01012345678")
+        form.domain = UserDomain(field: .tech)
+        form.cardColor = CardColor(color: .black)
+        
+        let result = form.build()
+        
+        #expect(result != nil)
     }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
@@ -1,0 +1,21 @@
+//
+//  BusinessCardFormTests.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/26/26.
+//
+
+import Testing
+@testable import Challenge2_BusinessCard
+
+struct BusinessCardFormTests {
+    
+    @Test
+    func 닉네임이_없으면_명함은_생성되지_않는다() {
+        let form = BusinessCardForm()
+        
+        #expect(throws: BusinessCardForm.BuildError.missingNickname) {
+            try form.build()
+        }
+    }
+}

--- a/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
@@ -28,4 +28,15 @@ struct BusinessCardFormTests {
             try form.build()
         }
     }
+    
+    @Test
+    func 전화번호가_없으면_명함은_생성되지_않는다() {
+        var form = BusinessCardForm()
+        form.nickname = Nickname(string: "Dustin")
+        form.name = Name(string: "가나다")
+        
+        #expect(throws: BusinessCardForm.BuildError.missingPhoneNumber) {
+            try form.build()
+        }
+    }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
@@ -51,4 +51,17 @@ struct BusinessCardFormTests {
             try form.build()
         }
     }
+    
+    @Test
+    func 명함_색상이_없으면_명함은_생성되지_않는다() {
+        var form = BusinessCardForm()
+        form.nickname = Nickname(string: "Dustin")
+        form.name = Name(string: "가나다")
+        form.phoneNumber = PhoneNumber(string: "01012345678")
+        form.domain = UserDomain(field: .tech)
+        
+        #expect(throws: BusinessCardForm.BuildError.missingCardColor) {
+            try form.build()
+        }
+    }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardFormTests.swift
@@ -18,4 +18,14 @@ struct BusinessCardFormTests {
             try form.build()
         }
     }
+    
+    @Test
+    func 이름이_없으면_명함은_생성되지_않는다() {
+        var form = BusinessCardForm()
+        form.nickname = Nickname(string: "Dustin")
+        
+        #expect(throws: BusinessCardForm.BuildError.missingName) {
+            try form.build()
+        }
+    }
 }

--- a/Challenge2-BusinessCardTests/CardColorTests.swift
+++ b/Challenge2-BusinessCardTests/CardColorTests.swift
@@ -17,4 +17,11 @@ struct CardColorTests {
         
         #expect(color == nil)
     }
+    
+    @Test("CardColor 생성", arguments: [Color.black, Color.blue, Color.red, Color.cyan])
+    func black_red_blue_cyan_색상으로만_CardColor_객체를_생성할_수_있다(color: Color) {
+        let color = CardColor(color: color)
+        
+        #expect(color != nil)
+    }
 }

--- a/Challenge2-BusinessCardTests/CardColorTests.swift
+++ b/Challenge2-BusinessCardTests/CardColorTests.swift
@@ -1,0 +1,20 @@
+//
+//  CardColorTests.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/27/26.
+//
+
+import SwiftUI
+import Testing
+@testable import Challenge2_BusinessCard
+
+struct CardColorTests {
+    
+    @Test
+    func black_red_blue_cyan_색상이_아닌_Color로_CardColor_객체를_생성할_수_없다() {
+        let color = CardColor(color: .brown)
+        
+        #expect(color == nil)
+    }
+}

--- a/Challenge2-BusinessCardTests/PhoneNumberTests.swift
+++ b/Challenge2-BusinessCardTests/PhoneNumberTests.swift
@@ -1,0 +1,21 @@
+//
+//  PhoneNumberTests.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/26/26.
+//
+
+import Testing
+@testable import Challenge2_BusinessCard
+
+struct PhoneNumberTests {
+    
+    @Test
+    func 전화번호가_010으로_시작하지_않는_경우_PhoneNumber_객체는_생성되지_않는다() {
+        let string = "0212345678"
+        
+        let phoneNumber = PhoneNumber(string: string)
+        
+        #expect(phoneNumber == nil)
+    }
+}

--- a/Challenge2-BusinessCardTests/PhoneNumberTests.swift
+++ b/Challenge2-BusinessCardTests/PhoneNumberTests.swift
@@ -20,9 +20,18 @@ struct PhoneNumberTests {
     }
     
     @Test("전화번호 유효성 테스트", arguments: ["0101234567", "010123456789"])
-    func 전화번호_010_뒷자리가_8자리가_아닌_경우_PhoneNumber_객체는_생성되지_않는다(string: String) {        
+    func 전화번호_010_뒷자리가_8자리가_아닌_경우_PhoneNumber_객체는_생성되지_않는다(string: String) {
         let phoneNumber = PhoneNumber(string: string)
         
         #expect(phoneNumber == nil)
+    }
+    
+    @Test
+    func 전화번호가_010으로_시작하고_뒷자리가_8자리인_경우_PhoneNumber_객체가_생성된다() {
+        let string = "01012345678"
+        
+        let phoneNumber = PhoneNumber(string: string)
+        
+        #expect(phoneNumber != nil)
     }
 }

--- a/Challenge2-BusinessCardTests/PhoneNumberTests.swift
+++ b/Challenge2-BusinessCardTests/PhoneNumberTests.swift
@@ -18,4 +18,11 @@ struct PhoneNumberTests {
         
         #expect(phoneNumber == nil)
     }
+    
+    @Test("전화번호 유효성 테스트", arguments: ["0101234567", "010123456789"])
+    func 전화번호_010_뒷자리가_8자리가_아닌_경우_PhoneNumber_객체는_생성되지_않는다(string: String) {        
+        let phoneNumber = PhoneNumber(string: string)
+        
+        #expect(phoneNumber == nil)
+    }
 }

--- a/Challenge2-BusinessCardTests/PhoneNumberTests.swift
+++ b/Challenge2-BusinessCardTests/PhoneNumberTests.swift
@@ -34,4 +34,13 @@ struct PhoneNumberTests {
         
         #expect(phoneNumber != nil)
     }
+    
+    @Test
+    func 전화번호는_공백으로_구분된다() {
+        let string = "01012345678"
+        
+        let phoneNumber = PhoneNumber(string: string)
+        
+        #expect(phoneNumber?.formatted == "010 1234 5678")
+    }
 }

--- a/Challenge2-BusinessCardTests/UserDomainTests.swift
+++ b/Challenge2-BusinessCardTests/UserDomainTests.swift
@@ -1,0 +1,17 @@
+//
+//  DomainTests.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 4/27/26.
+//
+
+import Testing
+@testable import Challenge2_BusinessCard
+
+struct DomainTests {
+    
+    @Test
+    func 도메인은() {
+        <#body#>
+    }
+}

--- a/Challenge2-BusinessCardTests/UserDomainTests.swift
+++ b/Challenge2-BusinessCardTests/UserDomainTests.swift
@@ -1,5 +1,5 @@
 //
-//  DomainTests.swift
+//  UserDomainTests.swift
 //  Challenge2-BusinessCard
 //
 //  Created by 더스틴 on 4/27/26.
@@ -8,10 +8,12 @@
 import Testing
 @testable import Challenge2_BusinessCard
 
-struct DomainTests {
+struct UserDomainTests {
     
-    @Test
-    func 도메인은() {
-        <#body#>
+    @Test("Domain 객체 생성", arguments: [Field.tech, Field.design, Field.domain])
+    func Field_열거형_케이스를_통해_Domain_객체를_생성할_수_있다(field: Field) {
+        let domain = UserDomain(field: field)
+        
+        #expect(domain.name == field.name)
     }
 }


### PR DESCRIPTION
## 💻 구현 내용

**1. 명함 생성 테스트코드를 작성했습니다.**

- [x] 닉네임, 이름, 도메인, 전화번호, 명함 색상 중 하나의 정보라도 채워지지 않은 경우 명함을 생성하지 않습니다.

**2. PhoneNumber, CardColor에 대한 테스트코드를 작성했습니다.**

- [x] 전화번호가 010으로 시작하지 않는 경우 PhoneNumber 객체는 생성되지 않는다
- [x] 전화번호가 010 뒷자리가 8자리가 아닌 경우 PhoneNumber 객체는 생성되지 않는다
- [x] 전화번호가 010으로 시작하고 뒷자리가 8자리인 경우 PhoneNumber 객체를 생성한다.
- [x] 전화번호는 공백으로 구분된다.
- [x] CardColor는 black, red, blue, cyan 색상으로만 생성 가능하다.   

**3. 명함 생성의 책임을 BusinessCardForm에 부여했습니다.**
```swift
struct BusinessCardForm {
    
    var nickname: Nickname?
    var name: Name?
    var phoneNumber: PhoneNumber?
    var domain: UserDomain?
    var cardColor: CardColor?
    
    func build() -> BusinessCard? {
        guard let nickname,
              let name,
              let phoneNumber,
              let domain,
              let cardColor
        else { return nil }
        
        return .init(
            nickname: nickname,
            name: name,
            phoneNumber: phoneNumber,
            field: domain,
            cardColor: cardColor,
            origin: CardOrigin.mine
        )
    }
}
```