### PR TITLE
[Test] 명함 삭제 및 조회 테스트

### DIFF
--- a/Challenge2-BusinessCard/Model/BusinessCards.swift
+++ b/Challenge2-BusinessCard/Model/BusinessCards.swift
@@ -20,4 +20,8 @@ class BusinessCards {
         let targetIndex = sharedCardIndices[index]
         return cards.remove(at: targetIndex)
     }
+    
+    func findByNickname(_ searchName: String) -> [BusinessCard] {
+        cards.filter { $0.nickname.contains(searchName) }
+    }
 }

--- a/Challenge2-BusinessCard/Model/BusinessCards.swift
+++ b/Challenge2-BusinessCard/Model/BusinessCards.swift
@@ -1,0 +1,23 @@
+//
+//  BusinessCards.swift
+//  Challenge2-BusinessCard
+//
+//  Created by 더스틴 on 5/8/26.
+//
+
+import SwiftData
+
+@Model
+class BusinessCards {
+    var cards: [BusinessCard]
+    
+    init(cards: [BusinessCard]) {
+        self.cards = cards
+    }
+    
+    func deleteCard(at index: Int) -> BusinessCard {
+        let sharedCardIndices = cards.indices.filter { cards[$0].origin == CardOrigin.shared.rawValue }
+        let targetIndex = sharedCardIndices[index]
+        return cards.remove(at: targetIndex)
+    }
+}

--- a/Challenge2-BusinessCard/Model/BusinessCards.swift
+++ b/Challenge2-BusinessCard/Model/BusinessCards.swift
@@ -21,7 +21,11 @@ class BusinessCards {
         return cards.remove(at: targetIndex)
     }
     
-    func findByNickname(_ searchName: String) -> [BusinessCard] {
-        cards.filter { $0.nickname.contains(searchName) }
+    func findByNickname(_ searchNickname: String) -> [BusinessCard] {
+        cards.filter { $0.nickname.contains(searchNickname) }
+    }
+    
+    func findByName(_ searchName: String) -> [BusinessCard] {
+        cards.filter { $0.name.contains(searchName) }
     }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardsTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardsTests.swift
@@ -66,11 +66,20 @@ struct BusinessCardsTests {
     }
     
     @Test("닉네임 기반 명함 검색", arguments: [("Ab", "Abcd"), ("Ef", nil)])
-    func 닉네임으로_명함을_검색할_수_있다(target: (searchName: String, nickname: String?)) {
+    func 닉네임으로_명함을_검색할_수_있다(target: (searchNickname: String, nickname: String?)) {
         guard let cards else { return }
         
-        let result = cards.findByNickname(target.searchName)
+        let result = cards.findByNickname(target.searchNickname)
         
         #expect(result.first?.nickname == target.nickname)
+    }
+    
+    @Test("이름 기반 명함 검색", arguments: [("가나", "가나다"), ("라마", nil)])
+    func 이름으로_명함을_검색할_수_있다(target: (searchName: String, name: String?)) {
+        guard let cards else { return }
+        
+        let result = cards.findByName(target.searchName)
+        
+        #expect(result.first?.name == target.name)
     }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardsTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardsTests.swift
@@ -1,19 +1,67 @@
 //
-//  BusinessCardListTests.swift
+//  BusinessCardsTests.swift
 //  Challenge2-BusinessCard
 //
 //  Created by 더스틴 on 4/29/26.
 //
 
+import SwiftUI
 import Testing
 @testable import Challenge2_BusinessCard
 
-struct BusinessCardListTests {
+struct BusinessCardsTests {
     
+    var cards: BusinessCards?
     
+    init() {
+        guard let nickname = Nickname(string: "Dustin"),
+              let name = Name(string: "허승준"),
+              let phoneNumber = PhoneNumber(string: "01012345678"),
+              let cardColor = CardColor(color: .black)
+        else {
+            return
+        }
+        
+        guard let nickname = Nickname(string: "Abcd"),
+              let name = Name(string: "가나다"),
+              let phoneNumber = PhoneNumber(string: "01011112222"),
+              let cardColor = CardColor(color: .blue)
+        else {
+            return
+        }
+        
+        self.cards = BusinessCards(
+            cards: [
+                BusinessCard(
+                    nickname: nickname,
+                    name: name,
+                    phoneNumber: phoneNumber,
+                    field: UserDomain(field: .tech),
+                    cardColor: cardColor,
+                    origin: .mine
+                ),
+                BusinessCard(
+                    nickname: nickname,
+                    name: name,
+                    phoneNumber: phoneNumber,
+                    field: UserDomain(field: .design),
+                    cardColor: cardColor,
+                    origin: .shared
+                )
+            ]
+        )
+    }
     
     @Test
-    func 명함의_닉네임을_수정할_수_있다() {
-        <#body#>
+    func 인덱스_기반으로_명함을_삭제할_수_있다() {
+        guard let cards else { return }
+        
+        let isDeleted = cards.deleteCard(at: 0)
+        
+        #expect(isDeleted.nickname == "Abcd")
+        #expect(isDeleted.name == "가나다")
+        #expect(isDeleted.phoneNumber == "010 1111 2222")
+        #expect(isDeleted.field == Field.design.name)
+        #expect(isDeleted.origin == CardOrigin.shared.rawValue)
     }
 }

--- a/Challenge2-BusinessCardTests/BusinessCardsTests.swift
+++ b/Challenge2-BusinessCardTests/BusinessCardsTests.swift
@@ -14,18 +14,18 @@ struct BusinessCardsTests {
     var cards: BusinessCards?
     
     init() {
-        guard let nickname = Nickname(string: "Dustin"),
-              let name = Name(string: "허승준"),
-              let phoneNumber = PhoneNumber(string: "01012345678"),
-              let cardColor = CardColor(color: .black)
+        guard let nickname1 = Nickname(string: "Dustin"),
+              let name1 = Name(string: "허승준"),
+              let phoneNumber1 = PhoneNumber(string: "01012345678"),
+              let cardColor1 = CardColor(color: .black)
         else {
             return
         }
         
-        guard let nickname = Nickname(string: "Abcd"),
-              let name = Name(string: "가나다"),
-              let phoneNumber = PhoneNumber(string: "01011112222"),
-              let cardColor = CardColor(color: .blue)
+        guard let nickname2 = Nickname(string: "Abcd"),
+              let name2 = Name(string: "가나다"),
+              let phoneNumber2 = PhoneNumber(string: "01011112222"),
+              let cardColor2 = CardColor(color: .blue)
         else {
             return
         }
@@ -33,19 +33,19 @@ struct BusinessCardsTests {
         self.cards = BusinessCards(
             cards: [
                 BusinessCard(
-                    nickname: nickname,
-                    name: name,
-                    phoneNumber: phoneNumber,
+                    nickname: nickname1,
+                    name: name1,
+                    phoneNumber: phoneNumber1,
                     field: UserDomain(field: .tech),
-                    cardColor: cardColor,
+                    cardColor: cardColor1,
                     origin: .mine
                 ),
                 BusinessCard(
-                    nickname: nickname,
-                    name: name,
-                    phoneNumber: phoneNumber,
+                    nickname: nickname2,
+                    name: name2,
+                    phoneNumber: phoneNumber2,
                     field: UserDomain(field: .design),
-                    cardColor: cardColor,
+                    cardColor: cardColor2,
                     origin: .shared
                 )
             ]
@@ -63,5 +63,14 @@ struct BusinessCardsTests {
         #expect(isDeleted.phoneNumber == "010 1111 2222")
         #expect(isDeleted.field == Field.design.name)
         #expect(isDeleted.origin == CardOrigin.shared.rawValue)
+    }
+    
+    @Test("닉네임 기반 명함 검색", arguments: [("Ab", "Abcd"), ("Ef", nil)])
+    func 닉네임으로_명함을_검색할_수_있다(target: (searchName: String, nickname: String?)) {
+        guard let cards else { return }
+        
+        let result = cards.findByNickname(target.searchName)
+        
+        #expect(result.first?.nickname == target.nickname)
     }
 }


### PR DESCRIPTION
## 💻 구현 내용

**1. 명함 삭제 및 조회 테스트 코드를 작성했습니다.**

- [x] 인덱스 기반으로 명함을 삭제할 수 있다.
- [x] 닉네임 및 이름 기반으로 명함을 검색할 수 있다. 

**2. BusinessCards 객체를 만들어 명함 삭제 및 검색 책임을 부여했습니다.**
```swift
@Model
class BusinessCards {
    var cards: [BusinessCard]
    
    init(cards: [BusinessCard]) {
        self.cards = cards
    }
    
    func deleteCard(at index: Int) -> BusinessCard {
        let sharedCardIndices = cards.indices.filter { cards[$0].origin == CardOrigin.shared.rawValue }
        let targetIndex = sharedCardIndices[index]
        return cards.remove(at: targetIndex)
    }
    
    func findByNickname(_ searchNickname: String) -> [BusinessCard] {
        cards.filter { $0.nickname.contains(searchNickname) }
    }
    
    func findByName(_ searchName: String) -> [BusinessCard] {
        cards.filter { $0.name.contains(searchName) }
    }
}
```